### PR TITLE
Fix #15: Explicitly add connexion with flask extra as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 bas-style-kit-jinja-templates
 bokeh
 connexion[swagger-ui]
+connexion[flask]
 flask<2.3.0
 Flask-HTTPAuth
 gunicorn


### PR DESCRIPTION
Fixes #15 

Simple, adds `connexion[flask]` to `requirements.txt`.